### PR TITLE
Add REPL pane

### DIFF
--- a/puppy/projects.py
+++ b/puppy/projects.py
@@ -3,6 +3,7 @@ import os
 from jinja2 import Environment, PackageLoader
 from .ui.editor import Editor
 from .ui.outputpane import OutputPane
+from .ui.replpane import REPLPane
 from .resources import load_svg
 
 # The encoding to use for reading/writing files
@@ -61,6 +62,8 @@ class HelloWorld(Project):
         self.ui.add_tab('hello_world.py')
         self.outputpane = OutputPane(parent=self.ui)
         self.ui.add_pane(self.outputpane)
+        self.replpane = REPLPane(port='/dev/ttyACM0', parent=self.ui)
+        self.ui.add_pane(self.replpane)
         return self.ui
 
     def run(self):

--- a/puppy/ui/replpane.py
+++ b/puppy/ui/replpane.py
@@ -1,0 +1,47 @@
+from PyQt5.QtWidgets import QTextEdit
+from PyQt5.QtGui import QTextCursor
+from PyQt5.QtCore import QIODevice
+from PyQt5.QtSerialPort import QSerialPort
+
+# TODO:
+#   - shutdown serial port cleanly on exit
+#   - use monospace font
+#   - get backspace and arrow keys working
+
+class REPLPane(QTextEdit):
+    def __init__(self, port, parent=None):
+        super().__init__(parent)
+        self.setAcceptRichText(False)
+        self.setReadOnly(False)
+        self.setLineWrapMode(QTextEdit.NoWrap)
+        self.setObjectName('replpane')
+
+        # open the serial port
+        self.serial = QSerialPort(self)
+        self.serial.setPortName(port)
+        self.serial.setBaudRate(115200)
+        print(self.serial.open(QIODevice.ReadWrite))
+        self.serial.readyRead.connect(self.on_serial_read)
+
+        # clear the text
+        self.clear()
+
+    def on_serial_read(self):
+        self.append(self.serial.readAll())
+
+    def keyPressEvent(self, data):
+        self.serial.write(bytes(data.text(), 'utf8'))
+
+    def append(self, txt):
+        tc = self.textCursor()
+        tc.movePosition(QTextCursor.End)
+        self.setTextCursor(tc)
+        self.insertPlainText(str(txt, 'utf8'))
+        self.ensureCursorVisible()
+
+    def clear(self):
+        self.setText('')
+
+    def kill(self):
+        if self.serial.isOpen():
+            self.serial.close()


### PR DESCRIPTION
A working REPL pane.  Proof of concept at the moment, but should be easy to clean up.  Defaults to connect to /dev/ttyACM0.

You may need to install qt5-serialport (or whatever the package is called for your Linux distro).
