### PR TITLE
Detect microbit

### DIFF
--- a/puppy/__main__.py
+++ b/puppy/__main__.py
@@ -81,7 +81,7 @@ def main():
     # Show the splash.
     splash.show()
 
-    # Make the editor with the Brian class defined above.
+    # Make the editor with the Puppy class defined above.
     the_editor = Puppy()
 
     proj_root = os.path.join(ROOT, 'hello_world')

--- a/puppy/projects.py
+++ b/puppy/projects.py
@@ -3,6 +3,7 @@ import os
 from jinja2 import Environment, PackageLoader
 from .ui.editor import Editor
 from .ui.outputpane import OutputPane
+from .ui.replpane import REPLPane
 from .resources import load_svg
 
 # The encoding to use for reading/writing files
@@ -61,6 +62,8 @@ class HelloWorld(Project):
         self.ui.add_tab('hello_world.py')
         self.outputpane = OutputPane(parent=self.ui)
         self.ui.add_pane(self.outputpane)
+        self.replpane = REPLPane(port='/dev/ttyACM0', parent=self.ui)
+        self.ui.add_pane(self.replpane)
         return self.ui
 
     def run(self):

--- a/puppy/projects.py
+++ b/puppy/projects.py
@@ -3,7 +3,7 @@ import os
 from jinja2 import Environment, PackageLoader
 from .ui.editor import Editor
 from .ui.outputpane import OutputPane
-from .ui.replpane import REPLPane
+from .ui.replpane import REPLPane, find_microbit
 from .resources import load_svg
 
 # The encoding to use for reading/writing files
@@ -62,8 +62,12 @@ class HelloWorld(Project):
         self.ui.add_tab('hello_world.py')
         self.outputpane = OutputPane(parent=self.ui)
         self.ui.add_pane(self.outputpane)
-        self.replpane = REPLPane(port='/dev/ttyACM0', parent=self.ui)
-        self.ui.add_pane(self.replpane)
+        mb_port = find_microbit()
+        if mb_port:
+            port = '/dev/{}'.format(mb_port)
+            print(port)
+            self.replpane = REPLPane(port=port, parent=self.ui)
+            self.ui.add_pane(self.replpane)
         return self.ui
 
     def run(self):

--- a/puppy/ui/replpane.py
+++ b/puppy/ui/replpane.py
@@ -1,0 +1,47 @@
+from PyQt5.QtWidgets import QTextEdit
+from PyQt5.QtGui import QTextCursor
+from PyQt5.QtCore import QIODevice
+from PyQt5.QtSerialPort import QSerialPort
+
+# TODO:
+#   - shutdown serial port cleanly on exit
+#   - use monospace font
+#   - get backspace and arrow keys working
+
+class REPLPane(QTextEdit):
+    def __init__(self, port, parent=None):
+        super().__init__(parent)
+        self.setAcceptRichText(False)
+        self.setReadOnly(False)
+        self.setLineWrapMode(QTextEdit.NoWrap)
+        self.setObjectName('replpane')
+
+        # open the serial port
+        self.serial = QSerialPort(self)
+        self.serial.setPortName(port)
+        self.serial.setBaudRate(115200)
+        print(self.serial.open(QIODevice.ReadWrite))
+        self.serial.readyRead.connect(self.on_serial_read)
+
+        # clear the text
+        self.clear()
+
+    def on_serial_read(self):
+        self.append(self.serial.readAll())
+
+    def keyPressEvent(self, data):
+        self.serial.write(bytes(data.text(), 'utf8'))
+
+    def append(self, txt):
+        tc = self.textCursor()
+        tc.movePosition(QTextCursor.End)
+        self.setTextCursor(tc)
+        self.insertPlainText(str(txt, 'utf8'))
+        self.ensureCursorVisible()
+
+    def clear(self):
+        self.setText('')
+
+    def kill(self):
+        if self.serial.isOpen():
+            self.serial.close()

--- a/puppy/ui/replpane.py
+++ b/puppy/ui/replpane.py
@@ -1,12 +1,30 @@
 from PyQt5.QtWidgets import QTextEdit
 from PyQt5.QtGui import QTextCursor
 from PyQt5.QtCore import QIODevice
-from PyQt5.QtSerialPort import QSerialPort
+from PyQt5.QtSerialPort import QSerialPort, QSerialPortInfo
 
 # TODO:
 #   - shutdown serial port cleanly on exit
 #   - use monospace font
 #   - get backspace and arrow keys working
+
+MICROBIT_PID = 516
+MICROBIT_VID = 3368
+
+
+def find_microbit():
+    """
+    Returns the port for the first microbit it finds connected to the host
+    computer. If no microbit is found, returns None.
+    """
+    available_ports = QSerialPortInfo.availablePorts()
+    for port in available_ports:
+        pid = port.productIdentifier()
+        vid = port.vendorIdentifier()
+        if pid == MICROBIT_PID and vid == MICROBIT_VID:
+            return port.portName()
+    return None
+
 
 class REPLPane(QTextEdit):
     def __init__(self, port, parent=None):
@@ -17,6 +35,7 @@ class REPLPane(QTextEdit):
         self.setObjectName('replpane')
 
         # open the serial port
+        import pdb; pdb.set_trace()
         self.serial = QSerialPort(self)
         self.serial.setPortName(port)
         self.serial.setBaudRate(115200)


### PR DESCRIPTION
@dpgeorge this stacks on top of your REPL branch. It introduces the following:
- Basic (Linux only atm) micro:bit detection.
- Delete works in the REPL
- Arrow keys also work although the response from the micro:bit needs to be handled properly.

@lordmauve I'm just adding capability here with little or no thought of where it should go atm. Once it works we can start to tidy up the user experience and different sorts of layouts.
